### PR TITLE
Revert "Upgrade to scalacheck-1.18.0"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     name := "scalacheck-xml",
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %%% "scala-xml" % "2.2.0",
-      "org.scalacheck" %%% "scalacheck" % "1.18.0"
+      "org.scalacheck" %%% "scalacheck" % "1.17.1"
     )
   )
   .platformsSettings(JSPlatform, NativePlatform)(


### PR DESCRIPTION
This reverts commit 39cdd81c1672bc890464023c0ac2ebb69075f4f6 because of missing Scala Native 0.5 dependenices.